### PR TITLE
Created function parsePosition

### DIFF
--- a/parsePosition
+++ b/parsePosition
@@ -1,0 +1,13 @@
+function parsedStruct = parsePosition(initialStruct)
+
+%split comma-dilimited sets (cells in cells)
+parsedStructCells = cellfun(@(x)regexp(x,',','split'),initialStruct,'UniformOutput',0) 
+
+%vertically concatinate the cells, turn 211x1 cell (of 1x3 cells) into a
+%211x3 cell
+parsedStructVC =vertcat(parsedStructCells{:})
+
+%turn 211x3 cell into 211x3 double 
+parsedStruct = cellfun(@str2double,parsedStructVC);
+ 
+end


### PR DESCRIPTION
Takes the comma-dilimited position coordinates in cells and converts them to a "#rows"x3 array of doubles with one col per coordinate (x in 1 col, y in 1 col and z in 1 col). 

created to format monleyLogic data such that it resembles old monkeylab data and can be processed with same functions. 

Run it with: 
parsedStruct = parsePosition(initialStruct);

Where:  
initialStruct = logicData(2).UEData.UE_Position